### PR TITLE
fix: improve IMAP validation and data handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: IMAP
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -125,4 +125,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/imap.json
+++ b/imap.json
@@ -21,7 +21,7 @@
     "python_version": "3.9, 3.13",
     "logo": "logo_splunk.svg",
     "logo_dark": "logo_splunk_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "configuration": {
         "server": {
             "data_type": "string",

--- a/imap.json
+++ b/imap.json
@@ -118,7 +118,7 @@
             "data_type": "boolean",
             "description": "Use SSL",
             "order": 14,
-            "default": false
+            "default": true
         },
         "extract_attachments": {
             "data_type": "boolean",

--- a/imap_connector.py
+++ b/imap_connector.py
@@ -657,6 +657,22 @@ class ImapConnector(BaseConnector):
         return self._parse_email(muuid, email_data, data_time_info)
 
     def _get_email_ids_to_process(self, max_emails, lower_id, manner):
+        max_emails = int(max_emails)
+
+        if manner == IMAP_INGEST_LATEST_EMAILS:
+            pending_uids = [int(uid) for uid in self._state.get("pending_email_uids", [])]
+            if pending_uids:
+                selected_uids = pending_uids[-max_emails:]
+                remaining_uids = pending_uids[:-max_emails]
+                if remaining_uids:
+                    self._state["pending_email_uids"] = remaining_uids
+                else:
+                    self._state.pop("pending_email_uids", None)
+                self.save_progress(
+                    f"Draining {len(selected_uids)} queued email UIDs; {len(remaining_uids)} remain from an earlier poll window"
+                )
+                return phantom.APP_SUCCESS, "", selected_uids
+
         try:
             # Method to fetch all UIDs
             result, data = self._imap_conn.uid("search", None, f"UID {lower_id!s}:*")
@@ -681,11 +697,14 @@ class ImapConnector(BaseConnector):
         # sort it
         uids.sort()
 
-        # see how many we are supposed to return
-        max_emails = int(max_emails)
-
         if manner == IMAP_INGEST_LATEST_EMAILS:
             self.save_progress(f"Getting {max_emails} MOST RECENT emails uids since uid(inclusive) {lower_id}")
+            if len(uids) > max_emails:
+                pending_uids = uids[:-max_emails]
+                self._state["pending_email_uids"] = pending_uids
+                self.save_progress(
+                    f"Poll window exceeded max_emails; queued {len(pending_uids)} older email UIDs for subsequent polls"
+                )
             # return the latest i.e. the rightmost items in the list
             return phantom.APP_SUCCESS, "", uids[-max_emails:]
 
@@ -891,7 +910,7 @@ class ImapConnector(BaseConnector):
                 return action_result.set_status(phantom.APP_ERROR)
 
         if email_ids:
-            self._state["next_muid"] = int(email_ids[-1]) + 1
+            self._state["next_muid"] = max(int(self._state.get("next_muid", 1)), int(email_ids[-1]) + 1)
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/imap_connector.py
+++ b/imap_connector.py
@@ -1,6 +1,6 @@
 # File: imap_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/imap_connector.py
+++ b/imap_connector.py
@@ -656,10 +656,10 @@ class ImapConnector(BaseConnector):
 
         return self._parse_email(muuid, email_data, data_time_info)
 
-    def _get_email_ids_to_process(self, max_emails, lower_id, manner):
+    def _get_email_ids_to_process(self, max_emails, lower_id, manner, persist_overflow=True):
         max_emails = int(max_emails)
 
-        if manner == IMAP_INGEST_LATEST_EMAILS:
+        if manner == IMAP_INGEST_LATEST_EMAILS and persist_overflow:
             pending_uids = [int(uid) for uid in self._state.get("pending_email_uids", [])]
             if pending_uids:
                 selected_uids = pending_uids[-max_emails:]
@@ -697,7 +697,7 @@ class ImapConnector(BaseConnector):
 
         if manner == IMAP_INGEST_LATEST_EMAILS:
             self.save_progress(f"Getting {max_emails} MOST RECENT emails uids since uid(inclusive) {lower_id}")
-            if len(uids) > max_emails:
+            if persist_overflow and len(uids) > max_emails:
                 pending_uids = uids[:-max_emails]
                 self._state["pending_email_uids"] = pending_uids
                 self.save_progress(f"Poll window exceeded max_emails; queued {len(pending_uids)} older email UIDs for subsequent polls")
@@ -841,7 +841,12 @@ class ImapConnector(BaseConnector):
             return action_result.get_status()
 
         self.save_progress(f"POLL NOW Getting {max_emails} most recent email uid(s)")
-        ret_val, ret_msg, email_ids = self._get_email_ids_to_process(max_emails, 1, config[IMAP_JSON_INGEST_MANNER])
+        ret_val, ret_msg, email_ids = self._get_email_ids_to_process(
+            max_emails,
+            1,
+            config[IMAP_JSON_INGEST_MANNER],
+            persist_overflow=False,
+        )
 
         if phantom.is_fail(ret_val):
             return action_result.set_status(ret_val, ret_msg)

--- a/imap_connector.py
+++ b/imap_connector.py
@@ -403,6 +403,24 @@ class ImapConnector(BaseConnector):
 
         self.save_progress(IMAP_CONNECTED_TO_SERVER)
 
+        # Basic authentication must never send mailbox credentials over a
+        # cleartext connection. Assets that explicitly disable implicit TLS
+        # therefore require a successful STARTTLS upgrade before LOGIN.
+        if not is_oauth and not use_ssl:
+            try:
+                result, data = self._imap_conn.starttls()
+            except Exception as e:
+                error_text = self._get_error_message_from_exception(e)
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to establish STARTTLS before login: {error_text}",
+                )
+            if result != "OK":
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to establish STARTTLS before login. Server response: {data}",
+                )
+
         # Login
         try:
             if is_oauth:

--- a/imap_connector.py
+++ b/imap_connector.py
@@ -668,9 +668,7 @@ class ImapConnector(BaseConnector):
                     self._state["pending_email_uids"] = remaining_uids
                 else:
                     self._state.pop("pending_email_uids", None)
-                self.save_progress(
-                    f"Draining {len(selected_uids)} queued email UIDs; {len(remaining_uids)} remain from an earlier poll window"
-                )
+                self.save_progress(f"Draining {len(selected_uids)} queued email UIDs; {len(remaining_uids)} remain from an earlier poll window")
                 return phantom.APP_SUCCESS, "", selected_uids
 
         try:
@@ -702,9 +700,7 @@ class ImapConnector(BaseConnector):
             if len(uids) > max_emails:
                 pending_uids = uids[:-max_emails]
                 self._state["pending_email_uids"] = pending_uids
-                self.save_progress(
-                    f"Poll window exceeded max_emails; queued {len(pending_uids)} older email UIDs for subsequent polls"
-                )
+                self.save_progress(f"Poll window exceeded max_emails; queued {len(pending_uids)} older email UIDs for subsequent polls")
             # return the latest i.e. the rightmost items in the list
             return phantom.APP_SUCCESS, "", uids[-max_emails:]
 
@@ -900,17 +896,27 @@ class ImapConnector(BaseConnector):
         if not email_ids:
             return action_result.set_status(phantom.APP_SUCCESS)
 
+        failed_email_ids = []
         for i, email_id in enumerate(email_ids):
             self.send_progress(f"Parsing email uid: {email_id}")
             try:
-                self._handle_email(email_id, param)
+                ret_val = self._handle_email(email_id, param)
+                if phantom.is_fail(ret_val):
+                    failed_email_ids.append(email_id)
+                    self.debug_print(f"Failed to process email uid {email_id}; continuing with the poll window")
             except Exception as e:
                 error_text = self._get_error_message_from_exception(e)
                 self.debug_print(f"ErrorExp in _handle_email # {i}", error_text)
-                return action_result.set_status(phantom.APP_ERROR)
+                failed_email_ids.append(email_id)
 
         if email_ids:
             self._state["next_muid"] = max(int(self._state.get("next_muid", 1)), int(email_ids[-1]) + 1)
+
+        if failed_email_ids:
+            return action_result.set_status(
+                phantom.APP_SUCCESS,
+                f"Skipped failed email UIDs and continued polling: {', '.join(str(uid) for uid in failed_email_ids)}",
+            )
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/imap_consts.py
+++ b/imap_consts.py
@@ -1,6 +1,6 @@
 # File: imap_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/process_email.py
+++ b/process_email.py
@@ -1,6 +1,6 @@
 # File: process_email.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/process_email.py
+++ b/process_email.py
@@ -914,7 +914,12 @@ class ProcessEmail:
         return
 
     def _int_process_email(self, rfc822_email, email_id, start_time_epoch):
-        mail = email.message_from_string(rfc822_email)
+        try:
+            mail = email.message_from_string(rfc822_email)
+        except Exception as e:
+            message = f"Failed to parse email {email_id}: {e}"
+            self._debug_print(message)
+            return phantom.APP_ERROR, message, []
 
         ret_val = phantom.APP_SUCCESS
 

--- a/process_email.py
+++ b/process_email.py
@@ -1022,12 +1022,34 @@ class ProcessEmail:
         vault_artifacts_added = 0
 
         last_file = len(files) - 1
+        automation_triggered = False
+        attachment_failures = []
         for i, curr_file in enumerate(files):
             run_automation = True if i == last_file else False
             ret_val, added_to_vault = self._handle_file(curr_file, vault_ids, container_id, vault_artifacts_added, run_automation)
 
-            if added_to_vault:
+            if not phantom.is_fail(ret_val) and not phantom.is_fail(added_to_vault):
                 vault_artifacts_added += 1
+                automation_triggered = automation_triggered or run_automation
+            else:
+                attachment_failures.append(curr_file.get("file_name") or curr_file.get("file_path") or f"attachment {i + 1}")
+
+        if attachment_failures:
+            self._base_connector.save_progress(
+                f"Failed to ingest {len(attachment_failures)} email attachment(s): {', '.join(attachment_failures)}"
+            )
+
+        if files and not automation_triggered:
+            fallback_artifact = {
+                **_artifact_common,
+                "container_id": container_id,
+                "name": "Email Ingestion Status",
+                "cef": {"attachmentIngestionStatus": "Completed with attachment errors"},
+                "run_automation": True,
+            }
+            self._set_sdi(fallback_artifact)
+            ret_val, status_string, _ = self._base_connector.save_artifact(fallback_artifact)
+            self._base_connector.debug_print(f"Fallback automation artifact returns, value: {ret_val}, reason: {status_string}")
 
         return
 
@@ -1146,6 +1168,9 @@ class ProcessEmail:
         vault_attach_dict[phantom.APP_JSON_APP_RUN_ID] = self._base_connector.get_app_run_id()
 
         file_name = self._decode_uni_string(file_name, file_name)
+        file_name = re.sub(r"[\x00-\x1f\x7f]", "_", file_name).strip()
+        if not file_name:
+            file_name = f"attachment-{artifact_id + 1}"
 
         try:
             success, message, vault_id = phantom_rules.vault_add(

--- a/process_email.py
+++ b/process_email.py
@@ -87,7 +87,10 @@ PROC_EMAIL_JSON_MSG_ID = "message_id"
 PROC_EMAIL_JSON_EMAIL_HEADERS = "email_headers"
 PROC_EMAIL_CONTENT_TYPE_MESSAGE = "message/rfc822"
 
-URI_REGEX = r"[Hh][Tt][Tt][Pp][Ss]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+URI_REGEX = (
+    r"([Hh][Tt][Tt][Pp][Ss]?:\/\/)((?:[:@\.\-_0-9]|[^ -@\[-\`\{-\~\s]|"
+    r"[\[\(][^\s\[\]\(\)]*[\]\)])+)((?:[\/\?]+(?:[^\[\'\"\(\{\)\]\}\s]|[\[\(][^\[\]\(\)]*[\]\)])*)*)[\/]?"
+)
 EMAIL_REGEX = r"\b[A-Z0-9._%+-]+@+[A-Z0-9.-]+\.[A-Z]{2,}\b"
 EMAIL_REGEX2 = r'".*"@[A-Z0-9.-]+\.[A-Z]{2,}\b'
 HASH_REGEX = r"\b[0-9a-fA-F]{32}\b|\b[0-9a-fA-F]{40}\b|\b[0-9a-fA-F]{64}\b"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,7 +1,7 @@
 **Unreleased**
 
-- Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]
-- Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]
-- Sanitize decoded attachment filenames and preserve the ingestion automation trigger when an attachment cannot be vaulted. [PAPP-38206, PSAAS-32039]
-- Queue overflowed UIDs during latest-first polling so subsequent polls ingest them instead of permanently skipping them. [PAPP-38206, PSAAS-32267]
-- Isolate malformed messages to their individual UID so polling continues and advances past poison emails. [PAPP-38206, PSAAS-32291]
+* Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]
+* Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]
+* Sanitize decoded attachment filenames and preserve the ingestion automation trigger when an attachment cannot be vaulted. [PAPP-38206, PSAAS-32039]
+* Queue overflowed UIDs during latest-first polling so subsequent polls ingest them instead of permanently skipping them. [PAPP-38206, PSAAS-32267]
+* Isolate malformed messages to their individual UID so polling continues and advances past poison emails. [PAPP-38206, PSAAS-32291]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]
+- Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 - Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]
 - Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]
 - Sanitize decoded attachment filenames and preserve the ingestion automation trigger when an attachment cannot be vaulted. [PAPP-38206, PSAAS-32039]
+- Queue overflowed UIDs during latest-first polling so subsequent polls ingest them instead of permanently skipping them. [PAPP-38206, PSAAS-32267]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 - Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]
 - Sanitize decoded attachment filenames and preserve the ingestion automation trigger when an attachment cannot be vaulted. [PAPP-38206, PSAAS-32039]
 - Queue overflowed UIDs during latest-first polling so subsequent polls ingest them instead of permanently skipping them. [PAPP-38206, PSAAS-32267]
+- Isolate malformed messages to their individual UID so polling continues and advances past poison emails. [PAPP-38206, PSAAS-32291]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 - Default new assets to SSL and require STARTTLS before basic authentication when implicit SSL is disabled. [PAPP-38206, PSAAS-30915]
 - Extract URLs whose hosts contain internationalized or mixed-script characters. [PAPP-38206, PSAAS-31928]
+- Sanitize decoded attachment filenames and preserve the ingestion automation trigger when an attachment cannot be vaulted. [PAPP-38206, PSAAS-32039]

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,6 +1,6 @@
 # File: request_handler.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- require encryption before basic IMAP login
- extract internationalized and mixed-script URLs
- sanitize attachment filenames and preserve ingestion automation after attachment failures
- drain latest-first poll overflow without skipping UIDs
- isolate malformed messages so polling advances past poison emails
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4

## Tracking

- PAPP-38206
- PSAAS-30915
- PSAAS-31928
- PSAAS-32039
- PSAAS-32267
- PSAAS-32291
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- local compile: passed
- hosted pre-commit and compile: passed
- unit tests: not applicable for this BaseConnector app
- integration and sanity results are non-blocking unless they identify a changed-code defect

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.

## Release impact

This PR contains a breaking configuration change and must ship as a major release. IMAP now defaults to encrypted connections and requires a successful TLS upgrade before basic authentication; existing assets must configure a trusted TLS endpoint or explicitly select a compatible secure mode. The corresponding functional commit includes a parseable `BREAKING CHANGE:` trailer for semantic-release.

Merge strategy: merge commit only; do not squash

Release-impact note added by Codex.